### PR TITLE
* Adds support for "java_prefix" attribute in namespace

### DIFF
--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -192,6 +192,7 @@ template<typename T> class SymbolTable {
 // A name space, as set in the schema.
 struct Namespace {
   std::vector<std::string> components;
+  SymbolTable<Value> attributes;
 
   // Given a (potentally unqualified) name, return the "fully qualified" name
   // which has a full namespaced descriptor.
@@ -450,6 +451,7 @@ class Parser : public ParserState {
     known_attributes_["csharp_partial"] = true;
     known_attributes_["streaming"] = true;
     known_attributes_["idempotent"] = true;
+	known_attributes_["java_prefix"] = true;
   }
 
   ~Parser() {

--- a/include/flatbuffers/idl.h
+++ b/include/flatbuffers/idl.h
@@ -451,7 +451,7 @@ class Parser : public ParserState {
     known_attributes_["csharp_partial"] = true;
     known_attributes_["streaming"] = true;
     known_attributes_["idempotent"] = true;
-	known_attributes_["java_prefix"] = true;
+    known_attributes_["java_prefix"] = true;
   }
 
   ~Parser() {

--- a/reflection/reflection.fbs
+++ b/reflection/reflection.fbs
@@ -3,7 +3,7 @@
 // This could be used to operate on unknown FlatBuffers at runtime.
 // It can even ... represent itself (!)
 
-namespace reflection;
+namespace reflection (java_prefix: "com.google.flatbuffers");
 
 // These must correspond to the enum in idl.h.
 enum BaseType : byte {

--- a/src/idl_gen_general.cpp
+++ b/src/idl_gen_general.cpp
@@ -258,7 +258,7 @@ class GeneralGenerator : public BaseGenerator {
 
     std::string code;
     code = code + "// " + FlatBuffersGeneratedWarning();
-    std::string namespace_name = FullNamespace(".", ns);
+    std::string namespace_name = FullNamespace(lang_.language, ".", ns);
     if (!namespace_name.empty()) {
       code += lang_.namespace_ident + namespace_name + lang_.namespace_begin;
       code += "\n\n";

--- a/src/idl_gen_php.cpp
+++ b/src/idl_gen_php.cpp
@@ -84,7 +84,7 @@ namespace php {
         if (!classcode.length()) return true;
 
         std::string code = "";
-        BeginFile(FullNamespace("\\", *def.defined_namespace),
+        BeginFile(FullNamespace(parser_.opts.lang, "\\", *def.defined_namespace),
                   needs_imports, &code);
         code += classcode;
 

--- a/src/idl_parser.cpp
+++ b/src/idl_parser.cpp
@@ -1467,6 +1467,7 @@ CheckedError Parser::ParseNamespace() {
       if (Is('.')) NEXT() else break;
     }
   }
+  ECHECK(ParseMetaData(&ns->attributes));
   EXPECT(';');
   return NoError();
 }


### PR DESCRIPTION
- Java generator now use "java_prefix" namespace attribute to prefix package name and place generated file in correct directory.
- Parser now collects namespace attributes
- Added "java_prefix" to know_attributes
- reflection.fbs will generate java code to com.google.flatbuffers

Notes that generated java reflection code has not been updated as it was already showing diff before this change.

NamespacePrefixAsComponents could be made simpler using a string tokenizer (not sure what is available while preserving portability).

Build pass on appveyor: https://ci.appveyor.com/project/blep/flatbuffers
